### PR TITLE
:sparkles: feat: Add bytecode to EVMts contract

### DIFF
--- a/.changeset/nine-socks-remain.md
+++ b/.changeset/nine-socks-remain.md
@@ -1,0 +1,12 @@
+---
+"@evmts/bundler": minor
+"@evmts/core": minor
+"@evmts/esbuild-plugin": minor
+"@evmts/rollup-plugin": minor
+"@evmts/rspack-plugin": minor
+"@evmts/vite-plugin": minor
+"@evmts/webpack-plugin": minor
+"@evmts/ts-plugin": minor
+---
+
+Added bytecode to EVMts contracts

--- a/bundlers/bundler/src/solc/solcPlugin.ts
+++ b/bundlers/bundler/src/solc/solcPlugin.ts
@@ -208,10 +208,11 @@ export const solcModules: SolidityResolver = (
 					`import { evmtsContractFactory } from '@evmts/core'`,
 				].join('\n')
 				const evmtsBody = Object.entries(artifacts)
-					.flatMap(([contractName, { abi }]) => {
+					.flatMap(([contractName, { abi, bytecode }]) => {
 						const contract = JSON.stringify({
 							name: contractName,
 							abi,
+							bytecode,
 							addresses:
 								config.deployments?.find(
 									(contractConfig) => contractConfig.name === contractName,
@@ -234,10 +235,11 @@ export const solcModules: SolidityResolver = (
 					`import { evmtsContractFactory } from '@evmts/core'`,
 				].join('\n')
 				const evmtsBody = Object.entries(artifacts)
-					.flatMap(([contractName, { abi }]) => {
+					.flatMap(([contractName, { abi, bytecode }]) => {
 						const contract = JSON.stringify({
 							name: contractName,
 							abi,
+							bytecode,
 							addresses:
 								config.deployments?.find(
 									(contractConfig) => contractConfig.name === contractName,
@@ -258,10 +260,11 @@ export const solcModules: SolidityResolver = (
 			if (artifacts) {
 				const evmtsImports = `const { evmtsContractFactory } = require('@evmts/core')`
 				const evmtsBody = Object.entries(artifacts)
-					.flatMap(([contractName, { abi }]) => {
+					.flatMap(([contractName, { abi, bytecode }]) => {
 						const contract = JSON.stringify({
 							name: contractName,
 							abi,
+							bytecode,
 							addresses:
 								config.deployments?.find(
 									(contractConfig) => contractConfig.name === contractName,
@@ -282,10 +285,11 @@ export const solcModules: SolidityResolver = (
 			if (artifacts) {
 				const evmtsImports = `const { evmtsContractFactory } = require('@evmts/core')`
 				const evmtsBody = Object.entries(artifacts)
-					.flatMap(([contractName, { abi }]) => {
+					.flatMap(([contractName, { abi, bytecode }]) => {
 						const contract = JSON.stringify({
 							name: contractName,
 							abi,
+							bytecode,
 							addresses:
 								config.deployments?.find(
 									(contractConfig) => contractConfig.name === contractName,
@@ -307,10 +311,11 @@ export const solcModules: SolidityResolver = (
 			if (artifacts) {
 				const evmtsImports = `import { evmtsContractFactory } from '@evmts/core'`
 				const evmtsBody = Object.entries(artifacts)
-					.flatMap(([contractName, { abi }]) => {
+					.flatMap(([contractName, { abi, bytecode }]) => {
 						const contract = JSON.stringify({
 							name: contractName,
 							abi,
+							bytecode,
 							addresses:
 								config.deployments?.find(
 									(contractConfig) => contractConfig.name === contractName,
@@ -331,10 +336,11 @@ export const solcModules: SolidityResolver = (
 			if (artifacts) {
 				const evmtsImports = `import { evmtsContractFactory } from '@evmts/core'`
 				const evmtsBody = Object.entries(artifacts)
-					.flatMap(([contractName, { abi }]) => {
+					.flatMap(([contractName, { abi, bytecode }]) => {
 						const contract = JSON.stringify({
 							name: contractName,
 							abi,
+							bytecode,
 							addresses:
 								config.deployments?.find(
 									(contractConfig) => contractConfig.name === contractName,

--- a/core/src/contract/contract.spec.ts
+++ b/core/src/contract/contract.spec.ts
@@ -71,10 +71,13 @@ describe('evmtsContractFactory', () => {
 		Address
 	>
 
+	const bytecode = '0x12345678'
+
 	const contract = evmtsContractFactory({
 		abi: dummyAbi,
 		name: 'DummyContract',
 		addresses: dummyAddresses,
+		bytecode,
 	})
 
 	it('should have correct name', () => {
@@ -91,6 +94,10 @@ describe('evmtsContractFactory', () => {
 
 	it('should contain the addresses', () => {
 		expect(contract.addresses).toEqual(dummyAddresses)
+	})
+
+	it('should contain the bytecode', () => {
+		expect(contract.bytecode).toEqual(bytecode)
 	})
 
 	describe('events', () => {

--- a/core/src/contract/contract.ts
+++ b/core/src/contract/contract.ts
@@ -23,6 +23,7 @@ export type EVMtsContract<
 > = {
 	abi: TAbi
 	humanReadableAbi: THumanReadableAbi
+	bytecode: string
 	name: TName
 	addresses: TAddresses
 	events: <TChainId extends keyof TAddresses>(options?: {
@@ -117,9 +118,10 @@ export const evmtsContractFactory = <
 	abi,
 	name,
 	addresses,
+	bytecode,
 }: Pick<
 	EVMtsContract<TName, TAddresses, TAbi>,
-	'name' | 'abi' | 'addresses'
+	'name' | 'abi' | 'addresses' | 'bytecode'
 >): EVMtsContract<TName, TAddresses, TAbi> => {
 	const methods = abi.filter((field) => {
 		return field.type === 'function'
@@ -232,6 +234,7 @@ export const evmtsContractFactory = <
 		abi,
 		humanReadableAbi: formatAbi(abi),
 		addresses,
+		bytecode,
 		events: events as any,
 		write: write as any,
 		read: read as any,


### PR DESCRIPTION
## Description

Add support for bytecode in EVMts contracts.  This enables usage of EVMts contracts to deploy in JS using viem or ethers

## Testing

Unit tests

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

