### PR TITLE
:construction_worker: fix(build): Add types folder to build output

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -43,7 +43,8 @@
       ],
       "outputs": [
         "{projectRoot}/dist",
-        "{projectRoot}/.vitepress"
+        "{projectRoot}/.vitepress",
+        "{projectRoot}/types"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Description

Nx cache was in bad state from forgetting to include types folder in build output

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

