### PR TITLE
:bug: fix(config): Make etherscan api keys partial

### DIFF
--- a/.changeset/mighty-schools-deliver.md
+++ b/.changeset/mighty-schools-deliver.md
@@ -1,0 +1,5 @@
+---
+"@evmts/config": patch
+---
+
+Fixed bug with etherscan section of the EvmtsConfig requiring all networks

--- a/bundlers/config/src/EVMtsConfig.ts
+++ b/bundlers/config/src/EVMtsConfig.ts
@@ -106,11 +106,7 @@ export const externalApiKeyValidator = z
 export type ExternalApiKey = z.infer<typeof externalApiKeyValidator>
 export const externalConfigValidator = z
 	.strictObject({
-		apiKeys: z
-			.strictObject({
-				etherscan: z.record(z.string().optional()),
-			})
-			.optional(),
+		apiKeys: externalApiKeyValidator.optional(),
 		contracts: z.array(etherscanConfigValidator),
 		out: z.string(),
 	})

--- a/bundlers/config/src/EVMtsConfig.ts
+++ b/bundlers/config/src/EVMtsConfig.ts
@@ -4,7 +4,8 @@ import { z } from 'zod'
 export const addressValidator = z
 	.string()
 	.transform((a) => a as Address)
-	.refine(isAddress)
+	.refine(isAddress, { message: 'Invalid ethereum address' }
+	)
 	.describe('Valid ethereum address')
 /**
  * Valid ethereum address
@@ -40,12 +41,13 @@ export type LocalContractsConfig<
 
 export const supportedEtherscanChainIdsValidator = z
 	.union([
-		z.literal(1),
-		z.literal(10),
-		z.literal(56),
-		z.literal(137),
-		z.literal(42161),
+		z.literal('1'),
+		z.literal('10'),
+		z.literal('56'),
+		z.literal('137'),
+		z.literal('42161'),
 	])
+	.transform((a) => Number.isInteger(a) ? a : Number.parseInt(a as string))
 	.describe('ChainIds of networks supported by etherscan')
 /**
  * ChainIds of networks supported by etherscan
@@ -78,6 +80,30 @@ export type EtherscanConfig = {
 	addresses: Partial<Record<SupportedEtherscanChainIds, Address>>
 }
 
+export const etherscanApiKeyValidator = z.strictObject({
+	'1': z.string().optional()
+		.describe('Api key for mainnet'),
+	'10': z.string().optional()
+		.describe('Api key for Optimism'),
+	'56': z.string().optional()
+		.describe('Api key for BSC'),
+	'137': z.string().optional()
+		.describe('Api key for Polygon'),
+	'42161': z.string().optional()
+		.describe('Api key for Arbitrum'),
+}).partial().describe('Api keys for etherscan by network')
+/**
+ * Api key for etherscan
+ */
+export type EtherscanApiKey = z.infer<typeof etherscanApiKeyValidator>
+export const externalApiKeyValidator = z
+	.strictObject({
+		etherscan: etherscanApiKeyValidator.optional(),
+	}).describe('Api keys for external services')
+/**
+ * Api keys for external services
+ */
+export type ExternalApiKey = z.infer<typeof externalApiKeyValidator>
 export const externalConfigValidator = z
 	.strictObject({
 		apiKeys: z
@@ -96,7 +122,7 @@ type ExternalConfig = {
 	/**
 	 * Api keys for external services
 	 */
-	apiKeys?: Record<'etherscan', Record<number, string>>
+	apiKeys?: Record<'etherscan', EtherscanApiKey>
 	/**
 	 * Array of external contracts to import
 	 */


### PR DESCRIPTION
## Description

The old zod validator required every etherscan network to be defined.
- use z.object().partial() instead of z.record()

## Testing

100% test coverage for this package

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

