### PR TITLE
:bug: fix(bundler): Use process.cwd() instead of '.'

### DIFF
--- a/.changeset/serious-shrimps-shave.md
+++ b/.changeset/serious-shrimps-shave.md
@@ -1,0 +1,5 @@
+---
+"@evmts/bundler": patch
+---
+
+Fixed mostly benign bug with using '.' instead of process.cwd()

--- a/bundlers/bundler/src/unplugin.spec.ts
+++ b/bundlers/bundler/src/unplugin.spec.ts
@@ -37,6 +37,12 @@ class MockUnpluginContext implements UnpluginContext, UnpluginBuildContext {
 
 let mockPlugin: MockUnpluginContext
 
+const mockCwd = 'mock/process/dot/cwd'
+vi.stubGlobal('process', {
+	...process,
+	cwd: () => mockCwd
+})
+
 describe('unpluginFn', () => {
 	const mockConfig = { config: 'mockedConfig' }
 
@@ -58,7 +64,7 @@ describe('unpluginFn', () => {
 		// call buildstart with mockPlugin as this
 		await plugin.buildStart?.call(mockPlugin)
 
-		expect(loadConfig).toHaveBeenCalledWith('.')
+		expect(loadConfig).toHaveBeenCalledWith(mockCwd)
 		expect((bundler as Mock).mock.lastCall).toMatchInlineSnapshot(`
 			[
 			  {

--- a/bundlers/bundler/src/unplugin.ts
+++ b/bundlers/bundler/src/unplugin.ts
@@ -45,7 +45,7 @@ export const unpluginFn: UnpluginFactory<
 		name: '@evmts/rollup-plugin',
 		version: '0.0.0',
 		async buildStart() {
-			config = loadConfig('.')
+			config = loadConfig(process.cwd())
 			moduleResolver = bundler(config, console)
 			this.addWatchFile('./tsconfig.json')
 		},


### PR DESCRIPTION
## Description

Didn't seem to be causing issues but using '.' instead of process.cwd() is not idiomatic and may have caused bugs

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

