### PR TITLE
:sparkles: feat(config): Add jsconfig.json support to EVMts

### DIFF
--- a/.changeset/fluffy-sloths-grow.md
+++ b/.changeset/fluffy-sloths-grow.md
@@ -1,0 +1,5 @@
+---
+"@evmts/config": minor
+---
+
+Added jsconfig.json support to EVMts. EVMts will now autodetect the tsconfig for both tsconfig.json and jsconfig.json. This enables support for JS with JSDoc comments as is popular in svelte and will be used in the upcoming Svelte example application.

--- a/config/src/loadConfig.spec.ts
+++ b/config/src/loadConfig.spec.ts
@@ -268,6 +268,70 @@ describe(loadConfig.name, () => {
 		expect(config).toStrictEqual(defaultConfig)
 	})
 
+	it('should work for a jsconfig.json', () => {
+		vi.spyOn(fs, 'existsSync').mockImplementation((path) => {
+			if (typeof path !== 'string') {
+				throw new Error('expected string!')
+			}
+			if (path.endsWith('tsconfig.json')) {
+				return false
+			}
+			if (path.endsWith('jsconfig.json')) {
+				return true
+			}
+			throw new Error(`unexpected path ${path}`)
+		})
+		vi.spyOn(fs, 'readFileSync').mockReturnValue(
+			JSON.stringify({
+				compilerOptions: {
+					plugins: [
+						{
+							name: '@evmts/ts-plugin',
+						},
+					],
+				},
+			}),
+		)
+		const mockFsReadFileSync = fs.readFileSync as MockedFunction<
+			typeof fs.readFileSync
+		>
+		expect(mockFsReadFileSync.mock.lastCall).toMatchInlineSnapshot('undefined')
+		const config = loadConfig('path/to/config')
+		expect(config).toStrictEqual(defaultConfig)
+	})
+
+	it('should work for a tsconfig.json', () => {
+		vi.spyOn(fs, 'existsSync').mockImplementation((path) => {
+			if (typeof path !== 'string') {
+				throw new Error('expected string!')
+			}
+			if (path.endsWith('tsconfig.json')) {
+				return true
+			}
+			if (path.endsWith('jsconfig.json')) {
+				return false
+			}
+			throw new Error(`unexpected path ${path}`)
+		})
+		vi.spyOn(fs, 'readFileSync').mockReturnValue(
+			JSON.stringify({
+				compilerOptions: {
+					plugins: [
+						{
+							name: '@evmts/ts-plugin',
+						},
+					],
+				},
+			}),
+		)
+		const mockFsReadFileSync = fs.readFileSync as MockedFunction<
+			typeof fs.readFileSync
+		>
+		expect(mockFsReadFileSync.mock.lastCall).toMatchInlineSnapshot('undefined')
+		const config = loadConfig('path/to/config')
+		expect(config).toStrictEqual(defaultConfig)
+	})
+
 	it('should return correct config and load foundry remappings when forge is set to true', () => {
 		vi.spyOn(fs, 'readFileSync').mockReturnValue(mockTsConfig())
 		vi.spyOn(fs, 'existsSync').mockReturnValue(true)

--- a/config/src/loadConfig.ts
+++ b/config/src/loadConfig.ts
@@ -1,6 +1,6 @@
 import { type EvmtsConfig, type ResolvedConfig } from './Config'
 import { defineConfig } from './defineConfig'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import * as path from 'path'
 
 type LoadConfig = (
@@ -14,9 +14,12 @@ export const loadConfig: LoadConfig = (configFilePath, logger = console) => {
 	 * for now load config will load from tsconfig instead until fixed
 	 */
 	const tsConfigPath = path.join(configFilePath, 'tsconfig.json')
+	const jsConfigPath = path.join(configFilePath, 'jsconfig.json')
 	let configStr
 	try {
-		configStr = readFileSync(tsConfigPath, 'utf8')
+		configStr = existsSync(jsConfigPath)
+			? readFileSync(jsConfigPath, 'utf8')
+			: readFileSync(tsConfigPath, 'utf8')
 	} catch (error) {
 		logger.error(error)
 		throw new Error(

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 			lines: 100,
 			statements: 100,
 			functions: 100,
-			branches: 95.18,
+			branches: 95.29,
 			thresholdAutoUpdate: true,
 		},
 	},


### PR DESCRIPTION
## Description

Added support for jsconfig.json to EVMts. If a jsconfig.json file exists evmts will autodetect it the same way it autodetects tsconfig.json

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

