### PR TITLE
:construction_worker: fix(mud): remove prepare script

### DIFF
--- a/examples/mud/package.json
+++ b/examples/mud/package.json
@@ -2,13 +2,15 @@
   "name": "mud-template-react",
   "private": true,
   "scripts": {
+    "prebuild": "(forge --version || pnpm foundry:up)",
     "build": "pnpm recursive run build",
+    "predev": "(forge --version || pnpm foundry:up)",
     "dev": "concurrently -n contracts,client -c cyan,magenta \"cd packages/contracts && pnpm run dev\" \"cd packages/client && pnpm run dev\"",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
-    "prepare": "(forge --version || pnpm foundry:up)",
+    "pretest": "pnpm recursive run test",
     "test": "pnpm recursive run test"
   },
   "devDependencies": {

--- a/examples/svelte-ethers/package.json
+++ b/examples/svelte-ethers/package.json
@@ -2,13 +2,19 @@
 	"name": "svelte-ethers",
 	"version": "0.1.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
 		"build": "vite build",
-		"preview": "vite preview",
 		"check": "echo 'cli typechecking will not be available until EVMts beta. Stay tuned to updates in the evmts/evmts-monorepo repo. Your editor should be able to provide typechecking in the meantime'",
 		"check:watch": "echo 'typechecking will not be available until EVMts beta. Stay tuned to updates in the evmts/evmts-monorepo repo. Your editor should be able to provide typechecking in the meantime'",
+		"dev": "vite dev",
+		"preview": "vite preview",
 		"test": "vitest"
+	},
+	"dependencies": {
+		"@evmts/core": "workspace:^",
+		"@evmts/ethers": "workspace:^",
+		"ethers": "^6.6.5"
 	},
 	"devDependencies": {
 		"@evmts/ts-plugin": "workspace:^",
@@ -22,11 +28,5 @@
 		"typescript": "^5.0.0",
 		"vite": "^4.4.2",
 		"vitest": "^0.33.0"
-	},
-	"type": "module",
-	"dependencies": {
-		"@evmts/core": "workspace:^",
-		"@evmts/ethers": "workspace:^",
-		"ethers": "^6.6.5"
 	}
 }

--- a/nx.json
+++ b/nx.json
@@ -35,7 +35,7 @@
 		},
 		"build": {
 			"inputs": ["production", "outputsDist"],
-			"dependsOn": ["^build:dist", "^build:types"],
+			"dependsOn": ["^build:dist", "^build:types", "prebuild"],
 			"outputs": [
 				"{projectRoot}/dist",
 				"{projectRoot}/.vitepress/dist",
@@ -48,7 +48,7 @@
 			"outputs": ["{projectRoot}/dist"]
 		},
 		"dev": {
-			"dependsOn": ["^build"]
+			"dependsOn": ["^build", "predev"]
 		}
 	},
 	"tasksRunnerOptions": {


### PR DESCRIPTION
## Description

Remove prepare script because it runs automatically after pnpm install. This breaks docs site on vercel needlessly from no forge being installed

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

