### PR TITLE
:zap: feat(bundler): Increase peformance by only returning the ast abi and userdoc

### DIFF
--- a/.changeset/friendly-cooks-juggle.md
+++ b/.changeset/friendly-cooks-juggle.md
@@ -1,0 +1,10 @@
+---
+"@evmts/bundler": minor
+"@evmts/rollup-plugin": minor
+"@evmts/vite-plugin": minor
+"@evmts/ethers": minor
+"@evmts/core": minor
+"@evmts/cli": minor
+---
+
+Major alpha change: remove bytecode from EVMts. Needing the bytecode is a niche use case and removing it improves peformance of the compiler significantly

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Support for all your favorite tools
 
 Try out our [online example on stackblitz](https://stackblitz.com/~/github.com/evmts/evmts-vite-wagmi-example)
 
-## Get Started Quick 
+## Get Started Quick
 
 EVMts provides many starter projects and reference code to help get you started
 
 - Our most popular project is the [NEXT.js and Wagmi starter project](https://github.com/evmts/evmts-next-example)
 - Our official starter project for react projects is the [Vite and wagmi starter project](https://github.com/evmts/evmts-vite-wagmi-example)
-- We don't only support react. Try out the [Svelte ethers starter project](https://github.com/evmts/evmts-svelte-ethers-example-) 
+- We don't only support react. Try out the [Svelte ethers starter project](https://github.com/evmts/evmts-svelte-ethers-example-)
 - Building a backend application or npm library? Check out the [esbuild and viem starter project](https://github.com/evmts/evmts-esbuild-viem-example)
 
 ## Visit [Docs](https://evmts.dev/) for docs, guides, API and more! 📄
@@ -77,21 +77,9 @@ contract ExampleContract is ERC20 {
 }
 ```
 
-### 2. Deploy your contract with Foundry, Hardhat, or even EVMts+Viem
+### 2. Deploy your contract with Foundry or Hardhat
 
-```typescript [deploy.ts]
-import {walletClient} from './viemWalletClient'
-import { ExampleContract } from '../contracts/ExampleContract.sol'
-
-const [account] = await walletClient.getAddresses();
-const hash = await walletClient.deployContract({
-  ...ExampleContract,
-  account,
-});
-console.log(hash)
-```
-
-### 3. Optional: Configure your contract address in your Evmts config 
+### 3. Optional: Configure your contract address in your Evmts config
 
 Configuring contract addresses for contracts you are developing in the Evmts config makes it so they automatically will have the correct address on whatever network you are using at the time without needing to import or specify them inline.
 
@@ -110,7 +98,7 @@ Configuring contract addresses for contracts you are developing in the Evmts con
 
 ```
 
-### 4. Optional: Install any external contracts 
+### 4. Optional: Install any external contracts
 
 Using a third-party contract? Simply add it to your Evmts config and run `evmts generate` to install the contracts into your project. No more copy-pasting abis.
 
@@ -175,7 +163,7 @@ export const ownerOf = (tokenId = BigInt(1)) => {
 - [@evmts/core](/core) - Contains core runtime code for Evmts contracts with first class [Wagmi](https://wagmi.sh/) and [Viem](https://viem.sh) support
 - [@evmts/ethers](/ethers) - Wrapper around ethers providing typesafe contracts directly with your EVMts contracts
 
-## CLI tools 
+## CLI tools
 
 - [@evmts/cli](/cli) - A cli tool for installing contracts from block explorers
 
@@ -274,7 +262,7 @@ Extra shoutout to Wagmi ABIType and Viem. Much of the code in this repo uses the
 
 This library has ambitious future plans to add features such as
 - Ability to use forge scripts in your clientside or serverside JavaScript code
-- A clientside VM 
+- A clientside VM
 - Instant gas estimation calculated clientside
 - Optimistic execution
 - Trustless RPC layer

--- a/bundlers/bundler/src/bundler.spec.ts
+++ b/bundlers/bundler/src/bundler.spec.ts
@@ -301,7 +301,7 @@ describe(bundler.name, () => {
 
 		it('should generate proper dts if artifacts are found', async () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifacts.mockResolvedValueOnce({
 				artifacts,
@@ -356,7 +356,6 @@ describe(bundler.name, () => {
 				TestContract: {
 					contractName: 'TestContract',
 					abi: erc20Abi,
-					bytecode: '0x420',
 				},
 			}
 			mockResolveArtifactsSync.mockReturnValueOnce({
@@ -454,7 +453,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper dts if artifacts are found', () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifactsSync.mockReturnValueOnce({
 				artifacts,
@@ -514,7 +513,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper dts if artifacts are found', () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			;(resolveArtifactsSync as Mock).mockReturnValueOnce({
 				artifacts,
@@ -524,7 +523,7 @@ export const WagmiReads = () => {
 			expect(result).toMatchInlineSnapshot(`
 				{
 				  "code": "import { evmtsContractFactory } from '@evmts/core'
-				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"bytecode\\":\\"\\",\\"addresses\\":{\\"10\\":\\"0x123\\"}} as const
+				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"addresses\\":{\\"10\\":\\"0x123\\"}} as const
 				export const TestContract = evmtsContractFactory(_TestContract)",
 				  "modules": {
 				    "module1": {
@@ -568,7 +567,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper dts if artifacts are found', async () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifacts.mockResolvedValueOnce({
 				artifacts,
@@ -578,7 +577,7 @@ export const WagmiReads = () => {
 			expect(result).toMatchInlineSnapshot(`
 				{
 				  "code": "import { evmtsContractFactory } from '@evmts/core'
-				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"bytecode\\":\\"\\",\\"addresses\\":{\\"10\\":\\"0x123\\"}} as const
+				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"addresses\\":{\\"10\\":\\"0x123\\"}} as const
 				export const TestContract = evmtsContractFactory(_TestContract)",
 				  "modules": {
 				    "module1": {
@@ -622,7 +621,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper CommonJS module if artifacts are found', () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifactsSync.mockReturnValueOnce({
 				artifacts,
@@ -632,7 +631,7 @@ export const WagmiReads = () => {
 			expect(result).toMatchInlineSnapshot(`
 				{
 				  "code": "const { evmtsContractFactory } = require('@evmts/core')
-				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"bytecode\\":\\"\\",\\"addresses\\":{\\"10\\":\\"0x123\\"}}
+				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"addresses\\":{\\"10\\":\\"0x123\\"}}
 				module.exports.TestContract = evmtsContractFactory(_TestContract)",
 				  "modules": {
 				    "module1": {
@@ -676,7 +675,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper CommonJS module if artifacts are found', async () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifacts.mockResolvedValueOnce({
 				artifacts,
@@ -686,7 +685,7 @@ export const WagmiReads = () => {
 			expect(result).toMatchInlineSnapshot(`
 				{
 				  "code": "const { evmtsContractFactory } = require('@evmts/core')
-				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"bytecode\\":\\"\\",\\"addresses\\":{\\"10\\":\\"0x123\\"}}
+				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"addresses\\":{\\"10\\":\\"0x123\\"}}
 				module.exports.TestContract = evmtsContractFactory(_TestContract)",
 				  "modules": {
 				    "module1": {
@@ -730,7 +729,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper ESM module if artifacts are found', () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifactsSync.mockReturnValueOnce({
 				artifacts,
@@ -740,7 +739,7 @@ export const WagmiReads = () => {
 			expect(result).toMatchInlineSnapshot(`
 				{
 				  "code": "import { evmtsContractFactory } from '@evmts/core'
-				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"bytecode\\":\\"\\",\\"addresses\\":{\\"10\\":\\"0x123\\"}}
+				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"addresses\\":{\\"10\\":\\"0x123\\"}}
 				export const TestContract = evmtsContractFactory(_TestContract)",
 				  "modules": {
 				    "module1": {
@@ -784,7 +783,7 @@ export const WagmiReads = () => {
 
 		it('should generate proper ESM module if artifacts are found', async () => {
 			const artifacts = {
-				TestContract: { contractName: 'TestContract', abi: [], bytecode: '' },
+				TestContract: { contractName: 'TestContract', abi: [] },
 			}
 			mockResolveArtifacts.mockResolvedValueOnce({
 				artifacts,
@@ -794,7 +793,7 @@ export const WagmiReads = () => {
 			expect(result).toMatchInlineSnapshot(`
 				{
 				  "code": "import { evmtsContractFactory } from '@evmts/core'
-				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"bytecode\\":\\"\\",\\"addresses\\":{\\"10\\":\\"0x123\\"}}
+				const _TestContract = {\\"name\\":\\"TestContract\\",\\"abi\\":[],\\"addresses\\":{\\"10\\":\\"0x123\\"}}
 				export const TestContract = evmtsContractFactory(_TestContract)",
 				  "modules": {
 				    "module1": {

--- a/bundlers/bundler/src/runtime/generateEvmtsBody.spec.ts
+++ b/bundlers/bundler/src/runtime/generateEvmtsBody.spec.ts
@@ -29,9 +29,9 @@ describe('generateEvmtsBody', () => {
 	it('should generate correct body for cjs module', () => {
 		const result = generateEvmtsBody(artifacts, config as any, 'cjs')
 		expect(result).toMatchInlineSnapshot(`
-			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016001\\",\\"addresses\\":{\\"test\\":\\"0x123\\"}}
+			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"addresses\\":{\\"test\\":\\"0x123\\"}}
 			module.exports.MyContract = evmtsContractFactory(_MyContract)
-			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016002\\",\\"addresses\\":{}}
+			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"addresses\\":{}}
 			module.exports.AnotherContract = evmtsContractFactory(_AnotherContract)"
 		`)
 	})
@@ -39,9 +39,9 @@ describe('generateEvmtsBody', () => {
 	it('should generate correct body for mjs module', () => {
 		const result = generateEvmtsBody(artifacts, config as any, 'mjs')
 		expect(result).toMatchInlineSnapshot(`
-			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016001\\",\\"addresses\\":{\\"test\\":\\"0x123\\"}}
+			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"addresses\\":{\\"test\\":\\"0x123\\"}}
 			export const MyContract = evmtsContractFactory(_MyContract)
-			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016002\\",\\"addresses\\":{}}
+			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"addresses\\":{}}
 			export const AnotherContract = evmtsContractFactory(_AnotherContract)"
 		`)
 	})
@@ -49,9 +49,9 @@ describe('generateEvmtsBody', () => {
 	it('should generate correct body for ts module', () => {
 		const result = generateEvmtsBody(artifacts, config as any, 'ts')
 		expect(result).toMatchInlineSnapshot(`
-			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016001\\",\\"addresses\\":{\\"test\\":\\"0x123\\"}} as const
+			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"addresses\\":{\\"test\\":\\"0x123\\"}} as const
 			export const MyContract = evmtsContractFactory(_MyContract)
-			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016002\\",\\"addresses\\":{}} as const
+			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"addresses\\":{}} as const
 			export const AnotherContract = evmtsContractFactory(_AnotherContract)"
 		`)
 	})
@@ -88,9 +88,9 @@ describe('generateEvmtsBody', () => {
 		}
 		const result = generateEvmtsBody(artifacts, configNoAddress as any, 'cjs')
 		expect(result).toMatchInlineSnapshot(`
-			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016001\\",\\"addresses\\":{}}
+			"const _MyContract = {\\"name\\":\\"MyContract\\",\\"abi\\":{},\\"addresses\\":{}}
 			module.exports.MyContract = evmtsContractFactory(_MyContract)
-			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"bytecode\\":\\"0x60016002\\",\\"addresses\\":{}}
+			const _AnotherContract = {\\"name\\":\\"AnotherContract\\",\\"abi\\":{},\\"addresses\\":{}}
 			module.exports.AnotherContract = evmtsContractFactory(_AnotherContract)"
 		`)
 	})

--- a/bundlers/bundler/src/runtime/generateEvmtsBody.ts
+++ b/bundlers/bundler/src/runtime/generateEvmtsBody.ts
@@ -5,7 +5,6 @@ type Artifacts = Record<
 	string,
 	{
 		abi: any
-		bytecode: string
 	}
 >
 
@@ -20,11 +19,10 @@ export const generateEvmtsBody = (
 		return generateDtsBody(artifacts, config)
 	}
 	return Object.entries(artifacts)
-		.flatMap(([contractName, { abi, bytecode }]) => {
+		.flatMap(([contractName, { abi }]) => {
 			const contract = JSON.stringify({
 				name: contractName,
 				abi,
-				bytecode,
 				addresses:
 					config.localContracts.contracts?.find(
 						(contractConfig) => contractConfig.name === contractName,

--- a/bundlers/bundler/src/runtime/generateEvmtsBodyDts.ts
+++ b/bundlers/bundler/src/runtime/generateEvmtsBodyDts.ts
@@ -5,7 +5,6 @@ type Artifacts = Record<
 	string,
 	{
 		abi: any
-		bytecode: string
 	}
 >
 

--- a/bundlers/bundler/src/runtime/generateRuntimeSync.spec.ts
+++ b/bundlers/bundler/src/runtime/generateRuntimeSync.spec.ts
@@ -22,7 +22,6 @@ describe('generateRuntimeSync', () => {
 	const artifacts: Artifacts = {
 		MyContract: {
 			abi: [{ type: 'constructor', inputs: [] }],
-			bytecode: '0x60016001',
 			contractName: 'MyContract',
 		},
 	}

--- a/bundlers/bundler/src/solc/compileContracts.spec.ts
+++ b/bundlers/bundler/src/solc/compileContracts.spec.ts
@@ -139,7 +139,7 @@ describe('compileContractSync', () => {
 		)
 		expect((solc.compile as Mock).mock.lastCall).toMatchInlineSnapshot(`
 			[
-			  "{\\"language\\":\\"Solidity\\",\\"sources\\":{\\"test/path\\":{\\"content\\":\\"import test/path/resolutionFile.sol\\\\ncontract Test {}\\"},\\"test/path/resolutionFile.sol\\":{\\"content\\":\\"contract Resolution {}\\"}},\\"settings\\":{\\"outputSelection\\":{\\"*\\":{\\"*\\":[\\"*\\"]}}}}",
+			  "{\\"language\\":\\"Solidity\\",\\"sources\\":{\\"test/path\\":{\\"content\\":\\"import test/path/resolutionFile.sol\\\\ncontract Test {}\\"},\\"test/path/resolutionFile.sol\\":{\\"content\\":\\"contract Resolution {}\\"}},\\"settings\\":{\\"outputSelection\\":{\\"*\\":{\\"\\":[\\"ast\\"],\\"*\\":[\\"abi\\",\\"userdoc\\"]}}}}",
 			]
 		`)
 	})

--- a/bundlers/bundler/src/solc/compileContracts.ts
+++ b/bundlers/bundler/src/solc/compileContracts.ts
@@ -1,10 +1,15 @@
+import { readFileSync } from 'fs'
+import type { ResolvedConfig } from '@evmts/config'
+import * as resolve from 'resolve'
 import type { ModuleInfo } from '../types'
 import { invariant } from '../utils/invariant'
 import { moduleFactory } from './moduleFactory'
-import { type SolcInputDescription, type SolcOutput, solcCompile } from './solc'
-import type { ResolvedConfig } from '@evmts/config'
-import { readFileSync } from 'fs'
-import * as resolve from 'resolve'
+import {
+	type SolcInputDescription,
+	type SolcOutput,
+	fileLevelOption,
+	solcCompile,
+} from './solc'
 
 // Compile the Solidity contract and return its ABI and bytecode
 export const compileContractSync = (
@@ -68,7 +73,8 @@ export const compileContractSync = (
 		settings: {
 			outputSelection: {
 				'*': {
-					'*': ['*'],
+					[fileLevelOption]: ['ast'],
+					'*': ['abi', 'userdoc'],
 				},
 			},
 		},

--- a/bundlers/bundler/src/solc/compileContracts.ts
+++ b/bundlers/bundler/src/solc/compileContracts.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from 'fs'
-import type { ResolvedConfig } from '@evmts/config'
-import * as resolve from 'resolve'
 import type { ModuleInfo } from '../types'
 import { invariant } from '../utils/invariant'
 import { moduleFactory } from './moduleFactory'
@@ -10,8 +7,11 @@ import {
 	fileLevelOption,
 	solcCompile,
 } from './solc'
+import type { ResolvedConfig } from '@evmts/config'
+import { readFileSync } from 'fs'
+import * as resolve from 'resolve'
 
-// Compile the Solidity contract and return its ABI and bytecode
+// Compile the Solidity contract and return its ABI
 export const compileContractSync = (
 	filePath: string,
 	basedir: string,

--- a/bundlers/bundler/src/solc/resolveArtifacts.spec.ts
+++ b/bundlers/bundler/src/solc/resolveArtifacts.spec.ts
@@ -47,7 +47,6 @@ describe('resolveArtifacts', () => {
 			  "artifacts": {
 			    "Test": {
 			      "abi": [],
-			      "bytecode": "0x123",
 			      "contractName": "Test",
 			    },
 			  },

--- a/bundlers/bundler/src/solc/resolveArtifacts.ts
+++ b/bundlers/bundler/src/solc/resolveArtifacts.ts
@@ -11,10 +11,7 @@ export const resolveArtifacts = async (
 	logger: Logger,
 	config: ResolvedConfig,
 ): Promise<{
-	artifacts: Record<
-		string,
-		{ contractName: string; abi: any; bytecode: string }
-	>
+	artifacts: Record<string, { contractName: string; abi: any }>
 	modules: Record<'string', ModuleInfo>
 }> => {
 	return resolveArtifactsSync(solFile, basedir, logger, config)

--- a/bundlers/bundler/src/solc/resolveArtifactsSync.spec.ts
+++ b/bundlers/bundler/src/solc/resolveArtifactsSync.spec.ts
@@ -47,7 +47,7 @@ const config: ResolvedConfig = defaultConfig
 const contracts = {
 	Test: {
 		abi: [],
-		evm: { bytecode: { object: '0x123' } },
+		evm: {},
 	},
 }
 
@@ -84,7 +84,6 @@ describe('resolveArtifactsSync', () => {
 			  "artifacts": {
 			    "Test": {
 			      "abi": [],
-			      "bytecode": "0x123",
 			      "contractName": "Test",
 			    },
 			  },
@@ -132,7 +131,6 @@ describe('resolveArtifactsSync', () => {
 			Test: {
 				contractName: 'Test',
 				abi: ['testAbi'],
-				bytecode: 'testBytecode',
 			},
 		})
 	})

--- a/bundlers/bundler/src/solc/resolveArtifactsSync.ts
+++ b/bundlers/bundler/src/solc/resolveArtifactsSync.ts
@@ -2,10 +2,7 @@ import type { Logger, ModuleInfo } from '../types'
 import { compileContractSync } from './compileContracts'
 import type { ResolvedConfig } from '@evmts/config'
 
-export type Artifacts = Record<
-	string,
-	{ contractName: string; abi: any; bytecode: string }
->
+export type Artifacts = Record<string, { contractName: string; abi: any }>
 
 export const resolveArtifactsSync = (
 	solFile: string,
@@ -34,8 +31,7 @@ export const resolveArtifactsSync = (
 		artifacts: Object.fromEntries(
 			Object.entries(artifacts).map(([contractName, contract]) => {
 				const abi = (contract as any).abi
-				const bytecode = (contract as any).evm.bytecode.object
-				return [contractName, { contractName, abi, bytecode }]
+				return [contractName, { contractName, abi }]
 			}),
 		),
 		modules,

--- a/bundlers/bundler/src/solc/solc.ts
+++ b/bundlers/bundler/src/solc/solc.ts
@@ -116,10 +116,15 @@ export type SolcOptimizer = {
 	details: SolcOptimizerDetails
 }
 
+export const fileLevelOption = '' as const
+
 export type SolcOutputSelection = {
 	[fileName: string]: {
-		[contractName: string]: Array<
+		[fileLevelOption]?: Array<'ast'>
+	} & {
+		[contractName: Exclude<string, typeof fileLevelOption>]: Array<
 			| 'abi'
+			// TODO this option is only for fileLevelOptions, but it's not clear how to type that
 			| 'ast'
 			| 'devdoc'
 			| 'evm.assembly'

--- a/bundlers/rollup/README.md
+++ b/bundlers/rollup/README.md
@@ -76,7 +76,6 @@ export default {
   contractPath,
   address,
   abi,
-  bytecode,
 };
 ```
 

--- a/bundlers/vite/README.md
+++ b/bundlers/vite/README.md
@@ -76,7 +76,6 @@ export default {
   contractPath,
   address,
   abi,
-  bytecode,
 };
 ```
 

--- a/cli/src/commands/generate/generate.ts
+++ b/cli/src/commands/generate/generate.ts
@@ -30,8 +30,6 @@ export const generate = async (
 			{
 				[contract.name]: {
 					abi: contract.abi,
-					// TODO handle pulling down the bytecode
-					bytecode: '0x0',
 					contractName: contract.name,
 				},
 			},
@@ -43,8 +41,6 @@ export const generate = async (
 			{
 				[contract.name]: {
 					abi: contract.abi,
-					// TODO handle pulling down the bytecode
-					bytecode: '0x0',
 					contractName: contract.name,
 				},
 			},

--- a/core/src/EvmtsContract.ts
+++ b/core/src/EvmtsContract.ts
@@ -11,7 +11,6 @@ export type EvmtsContract<
 > = {
 	abi: TAbi
 	humanReadableAbi: THumanReadableAbi
-	bytecode: `0x${string}`
 	name: TName
 	addresses: TAddresses
 	events: Events<TName, TAddresses, TAbi>

--- a/core/src/event/eventFactory.spec.ts
+++ b/core/src/event/eventFactory.spec.ts
@@ -8,13 +8,10 @@ const dummyAddresses = {
 	1: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
 } as const satisfies Record<number, Address>
 
-const bytecode = '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819'
-
 const contract = evmtsContractFactory({
 	abi: dummyAbi,
 	name: 'DummyContract',
 	addresses: dummyAddresses,
-	bytecode,
 })
 
 const dummyAbiNoEvent = dummyAbi.filter((abi) => abi.type !== 'event')
@@ -23,7 +20,6 @@ const contractNoEvent = evmtsContractFactory({
 	abi: dummyAbiNoEvent,
 	name: 'DummyContract',
 	addresses: dummyAddresses,
-	bytecode,
 })
 
 describe(eventsFactory.name, () => {

--- a/core/src/evmtsContractFactory.spec.ts
+++ b/core/src/evmtsContractFactory.spec.ts
@@ -7,14 +7,11 @@ const dummyAddresses = {
 	1: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
 } as const satisfies Record<number, Address>
 
-const bytecode = '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819'
-
 describe(evmtsContractFactory.name, () => {
 	const contract = evmtsContractFactory({
 		abi: dummyAbi,
 		name: 'DummyContract',
 		addresses: dummyAddresses,
-		bytecode,
 	})
 
 	it('should have correct name', () => {
@@ -31,10 +28,6 @@ describe(evmtsContractFactory.name, () => {
 
 	it('should contain the addresses', () => {
 		expect(contract.addresses).toEqual(dummyAddresses)
-	})
-
-	it('should contain the bytecode', () => {
-		expect(contract.bytecode).toEqual(bytecode)
 	})
 
 	it('should contain read', () => {
@@ -61,7 +54,6 @@ describe(evmtsContractFactory.name, () => {
 					number,
 					Address
 				>,
-				bytecode,
 			})
 		}).toThrowErrorMatchingInlineSnapshot(
 			'"\\"0xnot a valid addy is not a valid ethereum address"',

--- a/core/src/evmtsContractFactory.ts
+++ b/core/src/evmtsContractFactory.ts
@@ -14,10 +14,9 @@ export const evmtsContractFactory = <
 	abi,
 	name,
 	addresses,
-	bytecode,
 }: Pick<
 	EvmtsContract<TName, TAddresses, TAbi>,
-	'name' | 'abi' | 'addresses' | 'bytecode'
+	'name' | 'abi' | 'addresses'
 >): EvmtsContract<TName, TAddresses, TAbi> => {
 	Object.values(addresses).forEach((address) => {
 		if (!isAddress(address)) {
@@ -32,7 +31,6 @@ export const evmtsContractFactory = <
 		abi,
 		humanReadableAbi: formatAbi(abi),
 		addresses,
-		bytecode,
 		// TODO make this more internally typesafe
 		events: eventsFactory({ abi, addresses }) as any,
 		// TODO make this more internally typesafe

--- a/core/src/read/readFactory.spec.ts
+++ b/core/src/read/readFactory.spec.ts
@@ -8,13 +8,10 @@ const dummyAddresses = {
 	1: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
 } as const satisfies Record<number, Address>
 
-const bytecode = '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819'
-
 const contract = evmtsContractFactory({
 	abi: dummyAbi,
 	name: 'DummyContract',
 	addresses: dummyAddresses,
-	bytecode,
 })
 
 describe(readFactory.name, () => {
@@ -200,7 +197,6 @@ describe(readFactory.name, () => {
 			abi: dummyAbi,
 			name: 'DummyContract',
 			addresses: {},
-			bytecode,
 		})
 		const readFunc = c.read().exampleRead('data', BigInt(420))
 		expect(readFunc.address).toBeUndefined()

--- a/core/src/write/writeFactory.spec.ts
+++ b/core/src/write/writeFactory.spec.ts
@@ -8,13 +8,10 @@ const dummyAddresses = {
 	1: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
 } as const satisfies Record<number, Address>
 
-const bytecode = '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819'
-
 const contract = evmtsContractFactory({
 	abi: dummyAbi,
 	name: 'DummyContract',
 	addresses: dummyAddresses,
-	bytecode,
 })
 
 describe('write', () => {
@@ -170,7 +167,6 @@ describe('write', () => {
 			name: 'DummyContract',
 			// empty address
 			addresses: {},
-			bytecode,
 		})
 		const writeFunc = c.write().exampleWrite('data', BigInt(420))
 		expect(writeFunc.address).toBeUndefined()

--- a/ethers/src/createEthersContract.spec.ts
+++ b/ethers/src/createEthersContract.spec.ts
@@ -209,7 +209,6 @@ const evmtsContract = evmtsContractFactory({
 	abi,
 	name: 'test',
 	addresses: { 420: '0x32307adfFE088e383AFAa721b06436aDaBA47DBE' },
-	bytecode: '0x0',
 })
 
 const provider = new JsonRpcProvider('https://goerli.optimism.io', 420)
@@ -305,7 +304,6 @@ describe(createEthersContract.name, () => {
 			abi,
 			name: 'test',
 			addresses: { 420: '0xnot an ethereum address' },
-			bytecode: '0x0',
 		} as const
 		expect(() =>
 			createEthersContract(invalidContract, { runner: provider, chainId: 420 }),
@@ -326,7 +324,6 @@ describe(createEthersContract.name, () => {
 			abi,
 			name: 'test',
 			addresses: { 420: '0xnot an ethereum address' },
-			bytecode: '0x0',
 		} as const
 		expect(() =>
 			// @ts-expect-error

--- a/examples/vite/src/contracts/external/DAI.mjs
+++ b/examples/vite/src/contracts/external/DAI.mjs
@@ -262,7 +262,6 @@ const _DAI = {
 			type: 'function',
 		},
 	],
-	bytecode: '0x0',
 	addresses: {
 		1: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
 		10: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',

--- a/examples/vite/src/contracts/external/DAI.sol.mjs
+++ b/examples/vite/src/contracts/external/DAI.sol.mjs
@@ -262,7 +262,6 @@ const _DAI = {
 			type: 'function',
 		},
 	],
-	bytecode: '0x0',
 	addresses: {
 		1: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
 		10: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',


### PR DESCRIPTION
## Description

Make solc only return abi natspec and ast

Solc compilation is needlessly expensive because we are compiling bytecode and everything else as well. Bytecode is currently niche use case so remove to improve peformance

## Testing

Existing tests

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

