### PR TITLE
:memo: fix: jsdoc missing closing ```

### DIFF
--- a/config/docs/modules/defineConfig.md
+++ b/config/docs/modules/defineConfig.md
@@ -45,6 +45,7 @@ export default defineConfig(() => ({
 	  'foo': 'foo/bar'
 	}
 })
+```
 
 #### Defined in
 

--- a/config/src/defineConfig.js
+++ b/config/src/defineConfig.js
@@ -47,6 +47,7 @@ ${underlyingError.message}`,
  * 	  'foo': 'foo/bar'
  * 	}
  * })
+ * ```
  */
 export const defineConfig = (configFactory) => ({
 	configFn: (configFilePath) => {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"sort-package-json": "sort-package-json package.json 'plugins/*/package.json' 'examples/*/package.json' '*/package.json' 'packages/*/example/package.json'",
 		"sort-package-json:check": "sort-package-json package.json 'packages/*/package.json' '*/package.json' 'packages/*/example/package.json' && git diff --exit-code",
 		"test": "bun test:run",
-		"test:coverage": "nx run-many --target=test:coverage",
+		"test:coverage": "nx run-many --target=test:coverage --skip-nx-cache",
 		"test:run": "nx run-many --target=test:run"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Description

missing ``` was making jsdoc generated docs wrong

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

