### PR TITLE
:bug: Fix(vm): Add types to files in package.json

### DIFF
--- a/.changeset/yellow-birds-type.md
+++ b/.changeset/yellow-birds-type.md
@@ -1,0 +1,5 @@
+---
+"@evmts/vm": patch
+---
+
+Fixed bug with types missing from @evmts/vm package

--- a/vm/package.json
+++ b/vm/package.json
@@ -34,7 +34,9 @@
   "module": "dist/index.js",
   "types": "types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "types",
+    "src"
   ],
   "scripts": {
     "all": "bun i && bun run build && bun lint && bun format && bun test:run && bun generate:docs",


### PR DESCRIPTION
## Description

types folder was missing from @evmts/vm package when published to npm causing the types to not resolve

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

