### PR TITLE
:bug: Fix(webpack-plugin): Add loadInclude to unplugin

### DIFF
--- a/.changeset/warm-glasses-glow.md
+++ b/.changeset/warm-glasses-glow.md
@@ -1,0 +1,6 @@
+---
+"@evmts/unplugin": patch
+"@evmts/webpack-plugin": patch
+---
+
+Fixed bug with webpack plugin attempting to parse non javascript files

--- a/bundler/unplugin/src/evmtsUnplugin.js
+++ b/bundler/unplugin/src/evmtsUnplugin.js
@@ -63,10 +63,18 @@ export const evmtsUnplugin = (options = {}) => {
 
 	return {
 		name: '@evmts/rollup-plugin',
+		enforce: 'pre',
 		async buildStart() {
 			config = runSync(loadConfig(process.cwd()))
 			moduleResolver = bundler(config, console, fao, solcCache)
 			this.addWatchFile('./tsconfig.json')
+		},
+		loadInclude: (id) => {
+			return (
+				id.endsWith('.sol') &&
+				!existsSync(`${id}.ts`) &&
+				!existsSync(`${id}.d.ts`)
+			)
 		},
 		async resolveId(id, importer, options) {
 			// to handle the case where the import is coming from a node_module or a different workspace
@@ -82,16 +90,6 @@ export const evmtsUnplugin = (options = {}) => {
 			return null
 		},
 		async load(id) {
-			if (!id.endsWith('.sol')) {
-				return
-			}
-			if (existsSync(`${id}.ts`)) {
-				return
-			}
-			if (existsSync(`${id}.d.ts`)) {
-				return
-			}
-
 			const resolveBytecode = id.endsWith('.s.sol')
 
 			const { code, modules } = await moduleResolver.resolveEsmModule(


### PR DESCRIPTION
## Description

By not including a loadInclude the webpack plugin will attempt to parse non javascript files including html files.

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

