### PR TITLE
:construction_worker: Fix: Fix rome.json not ignoring nx

### DIFF
--- a/rome.json
+++ b/rome.json
@@ -4,6 +4,7 @@
 	},
 	"files": {
 		"ignore": [
+			".nx",
 			"node_modules",
 			"**/coverage",
 			"**/node_modules",


### PR DESCRIPTION
## Description

Not ignoring nx file caused it to lint a huge file

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

